### PR TITLE
Fix Problems in Openhab

### DIFF
--- a/CalSyncHAB.py
+++ b/CalSyncHAB.py
@@ -64,10 +64,10 @@ def Main():
         OpenHABResponse = requests.post(CalendarEventDescriptionItemURL, data = '', allow_redirects = True)
         
         CalendarEventStartTimeItemURL = 'http://' + TrimmedHostAndPort + '/rest/items/' + S.OpenHABItemPrefix + 'Event' + str(EventCounter) + '_StartTime'
-        OpenHABResponse = requests.post(CalendarEventStartTimeItemURL, data = 'UNDEF', allow_redirects = True)
+        OpenHABResponse = requests.post(CalendarEventStartTimeItemURL, data = '1909-12-19T00:00:00.000+0100', allow_redirects = True)
 
         CalendarEventEndTimeItemURL = 'http://' + TrimmedHostAndPort + '/rest/items/' + S.OpenHABItemPrefix + 'Event' + str(EventCounter) + '_EndTime'
-        OpenHABResponse = requests.post(CalendarEventEndTimeItemURL, data = 'UNDEF', allow_redirects = True)
+        OpenHABResponse = requests.post(CalendarEventEndTimeItemURL, data = '1909-12-19T00:00:00.000+0100', allow_redirects = True)
 
     time.sleep(2)
 

--- a/CalSyncHAB.py
+++ b/CalSyncHAB.py
@@ -41,17 +41,19 @@ def Main():
 
     RetrievedEvents = CalendarEvents.get('items', [])
 
-    if not RetrievedEvents:
-        print('No upcoming events found.')
+    MaxEvents = int(S.CalendarMaxEvents)
 
     if S.OpenHABPort.strip() != '':
         TrimmedHostAndPort = S.OpenHABHostName.strip() + ':' + S.OpenHABPort.strip()
     else:
         TrimmedHostAndPort = S.OpenHABHostName.strip()
 
+    if not RetrievedEvents:
+        print('No upcoming events found.')
+        
     EventCounter = 0
 
-    for SingleEvent in RetrievedEvents:
+    for SingleEvent in range(0, MaxEvents):
         EventCounter += 1
 
         CalendarEventSummaryItemURL = 'http://' + TrimmedHostAndPort + '/rest/items/' + S.OpenHABItemPrefix + 'Event' + str(EventCounter) + '_Summary'
@@ -68,7 +70,7 @@ def Main():
 
         CalendarEventEndTimeItemURL = 'http://' + TrimmedHostAndPort + '/rest/items/' + S.OpenHABItemPrefix + 'Event' + str(EventCounter) + '_EndTime'
         OpenHABResponse = requests.post(CalendarEventEndTimeItemURL, data = '1909-12-19T00:00:00.000+0100', allow_redirects = True)
-
+        
     time.sleep(2)
 
     EventCounter = 0

--- a/CalSyncHAB.py
+++ b/CalSyncHAB.py
@@ -40,16 +40,15 @@ def Main():
         orderBy = 'startTime').execute()
 
     RetrievedEvents = CalendarEvents.get('items', [])
-
     MaxEvents = int(S.CalendarMaxEvents)
+
+    if not RetrievedEvents:
+        print('No upcoming events found.')
 
     if S.OpenHABPort.strip() != '':
         TrimmedHostAndPort = S.OpenHABHostName.strip() + ':' + S.OpenHABPort.strip()
     else:
         TrimmedHostAndPort = S.OpenHABHostName.strip()
-
-    if not RetrievedEvents:
-        print('No upcoming events found.')
         
     EventCounter = 0
 


### PR DESCRIPTION
Send a DateTime String in the Past ... UNDEF makes Warnings in Openhab Log

Fixed Problem, when Upcoming Events are lower then MaxEvents.... then not all Items in Openhab cleared ... Thats only a Problem when Deleting Events and Upcoming Events are Lower then MaxEvents